### PR TITLE
Only show table when selected

### DIFF
--- a/SearchTextField/Classes/SearchTextField.swift
+++ b/SearchTextField/Classes/SearchTextField.swift
@@ -252,7 +252,7 @@ open class SearchTextField: UITextField {
     
     // Handle keyboard events
     open func keyboardWillShow(_ notification: Notification) {
-        if !keyboardIsShowing {
+        if !keyboardIsShowing && isEditing {
             keyboardIsShowing = true
             keyboardFrame = ((notification as NSNotification).userInfo![UIKeyboardFrameEndUserInfoKey] as! NSValue).cgRectValue
             interactedWith = true


### PR DESCRIPTION
With the isEditing field in place it makes it so that the tables doesn't show up when selecting any other field.