### PR TITLE
1.1.3 - Custom Object for SearchTextFieldItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ mySearchTextField.startSuggestingInmediately = true
 
 ```
 
+### New feature: pass custom object to SearchTextFieldItem
+
+```swift
+public init(title: String, subtitle: String?, image: UIImage?, userInfo:[String:Any]?)
+
+```
+
 
 ## Swift Versions
 

--- a/SearchTextField.podspec
+++ b/SearchTextField.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "SearchTextField"
-  s.version          = "1.1.2"
+  s.version          = "1.1.3"
   s.summary          = "SearchTextField extends UITextField allowing you to add the autocomplete feature in a really easy way"
 
 # This description is used to generate tags and improve search results.

--- a/SearchTextField/Classes/SearchTextField.swift
+++ b/SearchTextField/Classes/SearchTextField.swift
@@ -561,6 +561,14 @@ public struct SearchTextFieldItem {
     public var title: String
     public var subtitle: String?
     public var image: UIImage?
+    public var userInfo : [String:Any]?
+    
+    public init(title: String, subtitle: String?, image: UIImage?, userInfo:[String:Any]?) {
+        self.title = title
+        self.subtitle = subtitle
+        self.image = image
+        self.userInfo = userInfo
+    }
     
     public init(title: String, subtitle: String?, image: UIImage?) {
         self.title = title


### PR DESCRIPTION
As far as SearchTextFieldItem is Struct, and therefore impossible to extend...I've decided to create some generic way to pass object to item itself (which is not going to be displayed as title / subtitle)