### PR TITLE
Add config option to always show suggestion list

### DIFF
--- a/SearchTextField/Classes/SearchTextField.swift
+++ b/SearchTextField/Classes/SearchTextField.swift
@@ -24,6 +24,9 @@ open class SearchTextField: UITextField {
     
     /// Indicate if keyboard is showing or not
     open var keyboardIsShowing = false
+
+    /// Always show the entire suggestions list but continue to highlight the matching text
+    open var alwaysShowAllSuggestions = false
     
     /// Set your custom visual theme, or just choose between pre-defined SearchTextFieldTheme.lightTheme() and SearchTextFieldTheme.darkTheme() themes
     open var theme = SearchTextFieldTheme.lightTheme() {
@@ -134,7 +137,7 @@ open class SearchTextField: UITextField {
     fileprivate var filteredResults = [SearchTextFieldItem]()
     fileprivate var filterDataSource = [SearchTextFieldItem]() {
         didSet {
-            filter(forceShowAll: false)
+            filter(forceShowAll: alwaysShowAllSuggestions ? true : false)
             buildSearchTableView()
             
             if startVisibleWithoutInteraction {
@@ -361,7 +364,7 @@ open class SearchTextField: UITextField {
             }
             self.placeholderLabel?.text = ""
         } else {
-            filter(forceShowAll: false)
+            filter(forceShowAll: alwaysShowAllSuggestions ? true : false)
             prepareDrawTableResult()
         }
         


### PR DESCRIPTION
This feature is useful if we are doing the actual filtering we need via a REST service and we want to show all the results it returns. If the exact text matches, the highlight will continue to be displayed. This is useful if the user is searching for values that may exist in metadata but not always displayed on the title or subtitle.