### PR TITLE
Sets estimated row height to prevent jiggling list

### DIFF
--- a/SearchTextField/Classes/SearchTextField.swift
+++ b/SearchTextField/Classes/SearchTextField.swift
@@ -267,6 +267,12 @@ open class SearchTextField: UITextField {
         if let tableView = tableView {
             guard let frame = self.superview?.convert(self.frame, to: nil) else { return }
             
+            //TableViews use estimated cell heights to calculate content size until they
+            //  are on-screen. We must set this to the theme cell height to avoid getting an
+            //  incorrect contentSize when we have specified non-standard fonts and/or
+            //  cellHeights in the theme. We do it here to ensure updates to these settings
+            //  are recognized if changed after the tableView is created
+            tableView.estimatedRowHeight = theme.cellHeight
             if self.direction == .down {
                 
                 var tableHeight: CGFloat = 0


### PR DESCRIPTION
The code before this patch would jiggle if you set the font size to a high value
and also happened to set a larger cell size. Upon investigation, this is
caused by the default row-estimation behavior of UITableView. This behavior
is to return estimated values until the tableView is onscreen. By setting the
row estimate to our theme height, the contentSize returned matches the expected
size upon screen.

This makes the layout math work correctly, thereby stopping the prominent 
jiggle you can see as you type sometimes, as well as the incorrect list height that's
\# of visible cells X (theme.cellHeight - 44) off from what's expected sometimes. 