### PR TITLE
Update SearchTextField.swift

### DIFF
--- a/SearchTextField/Classes/SearchTextField.swift
+++ b/SearchTextField/Classes/SearchTextField.swift
@@ -460,7 +460,7 @@ open class SearchTextField: UITextField {
                 }
                 
                 if item.title.lowercased().hasPrefix(textToFilter) {
-                    let indexFrom = textToFilter.index(textToFilter.startIndex, offsetBy: textToFilter.characters.count)
+                    let indexFrom = textToFilter.index(textToFilter.startIndex, offsetBy: textToFilter.count)
                     let itemSuffix = item.title[indexFrom...]
                     
                     item.attributedTitle = NSMutableAttributedString(string: String(itemSuffix))


### PR DESCRIPTION
Swift 4 update: replace use of String.characters.count (deprecated) with String.count