### PR TITLE
Fix initial status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+xcuserdata

--- a/SearchTextField/Classes/SearchTextField.swift
+++ b/SearchTextField/Classes/SearchTextField.swift
@@ -205,27 +205,29 @@ open class SearchTextField: UITextField {
     
     // Create the filter table and shadow view
     fileprivate func buildSearchTableView() {
-        if let tableView = tableView, let shadowView = shadowView {
-            tableView.layer.masksToBounds = true
-            tableView.layer.borderWidth = theme.borderWidth > 0 ? theme.borderWidth : 0.5
-            tableView.dataSource = self
-            tableView.delegate = self
-            tableView.separatorInset = UIEdgeInsets.zero
-            tableView.tableHeaderView = resultsListHeader
-            if forceRightToLeft {
-                tableView.semanticContentAttribute = .forceRightToLeft
-            }
-            
-            shadowView.backgroundColor = UIColor.lightText
-            shadowView.layer.shadowColor = UIColor.black.cgColor
-            shadowView.layer.shadowOffset = CGSize.zero
-            shadowView.layer.shadowOpacity = 1
-            
-            self.window?.addSubview(tableView)
-        } else {
-            tableView = UITableView(frame: CGRect.zero)
-            shadowView = UIView(frame: CGRect.zero)
+        guard let tableView = tableView, let shadowView = shadowView else {
+            self.tableView = UITableView(frame: CGRect.zero)
+            self.shadowView = UIView(frame: CGRect.zero)
+            buildSearchTableView()
+            return
         }
+        
+        tableView.layer.masksToBounds = true
+        tableView.layer.borderWidth = theme.borderWidth > 0 ? theme.borderWidth : 0.5
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.separatorInset = UIEdgeInsets.zero
+        tableView.tableHeaderView = resultsListHeader
+        if forceRightToLeft {
+            tableView.semanticContentAttribute = .forceRightToLeft
+        }
+        
+        shadowView.backgroundColor = UIColor.lightText
+        shadowView.layer.shadowColor = UIColor.black.cgColor
+        shadowView.layer.shadowOffset = CGSize.zero
+        shadowView.layer.shadowOpacity = 1
+        
+        self.window?.addSubview(tableView)
         
         redrawSearchTableView()
     }

--- a/SearchTextField/Classes/SearchTextField.swift
+++ b/SearchTextField/Classes/SearchTextField.swift
@@ -301,6 +301,7 @@ open class SearchTextField: UITextField {
                 tableViewFrame.origin = self.convert(tableViewFrame.origin, to: nil)
                 tableViewFrame.origin.x += 2 + tableXOffset
                 tableViewFrame.origin.y += frame.size.height + 2 + tableYOffset
+                self.tableView?.frame.origin = tableViewFrame.origin // Avoid animating from (0, 0) when displaying at launch
                 UIView.animate(withDuration: 0.2, animations: { [weak self] in
                     self?.tableView?.frame = tableViewFrame
                 })


### PR DESCRIPTION
Before this PR it was not possible to display the list of suggestions with no input at launch.

No it can be achieved with the following options:

        searchField.forceNoFiltering = true
        searchField.filterStrings([])
        searchField.interactedWith = true

Still clunky, but an improvement.