### PR TITLE
add build folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 xcuserdata
+**/build/*


### PR DESCRIPTION
added the build folder to the gitignore so you don't have to run Xcode clean before each commit.