### PR TITLE
Fix empty placeholder crash, and remove deprecated method from iOS 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SearchTextField",
+    platforms: [
+           .iOS(.v9)
+       ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "SearchTextField",
+            targets: ["SearchTextField"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "SearchTextField",
+            dependencies: [],
+            path:"SearchTextField/Classes"
+        ),
+        .testTarget(
+            name: "SearchTextFieldTests",
+            dependencies: ["SearchTextField"],
+            path:"Tests")
+    ]
+)

--- a/SearchTextField/Classes/SearchTextField.swift
+++ b/SearchTextField/Classes/SearchTextField.swift
@@ -253,7 +253,8 @@ open class SearchTextField: UITextField {
             placeholderLabel?.backgroundColor = UIColor.clear
             placeholderLabel?.lineBreakMode = .byClipping
             
-            if let placeholderColor = self.attributedPlaceholder?.attribute(NSAttributedString.Key.foregroundColor, at: 0, effectiveRange: nil) as? UIColor {
+            if let attributedPlaceholder = self.attributedPlaceholder, attributedPlaceholder.length > 0,
+               let placeholderColor = attributedPlaceholder.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? UIColor {
                 placeholderLabel?.textColor = placeholderColor
             } else {
                 placeholderLabel?.textColor = UIColor ( red: 0.8, green: 0.8, blue: 0.8, alpha: 1.0 )

--- a/SearchTextField/Classes/SearchTextField.swift
+++ b/SearchTextField/Classes/SearchTextField.swift
@@ -144,7 +144,7 @@ open class SearchTextField: UITextField {
     fileprivate var timer: Timer? = nil
     fileprivate var placeholderLabel: UILabel?
     fileprivate static let cellIdentifier = "APSearchTextFieldCell"
-    fileprivate let indicator = UIActivityIndicatorView(style: .gray)
+    fileprivate let indicator = UIActivityIndicatorView(style: UIActivityIndicatorView.Style.medium)
     fileprivate var maxTableViewSize: CGFloat = 0
     
     fileprivate var filteredResults = [SearchTextFieldItem]()
@@ -530,7 +530,7 @@ open class SearchTextField: UITextField {
     // MARK: - Prepare for draw table result
     
     fileprivate func prepareDrawTableResult() {
-        guard let frame = self.superview?.convert(self.frame, to: UIApplication.shared.keyWindow) else { return }
+        guard let frame = self.superview?.convert(self.frame, to: UIApplication.shared.windows.first { $0.isKeyWindow }) else { return }
         if let keyboardFrame = keyboardFrame {
             var newFrame = frame
             newFrame.size.height += theme.cellHeight
@@ -543,7 +543,8 @@ open class SearchTextField: UITextField {
             
             redrawSearchTableView()
         } else {
-            if self.center.y + theme.cellHeight > UIApplication.shared.keyWindow!.frame.size.height {
+            let key = UIApplication.shared.windows.first { $0.isKeyWindow }
+            if self.center.y + theme.cellHeight > key!.frame.size.height {
                 direction = .up
             } else {
                 direction = .down

--- a/Tests/SearchTextFieldTests/SearchTextFieldTests.swift
+++ b/Tests/SearchTextFieldTests/SearchTextFieldTests.swift
@@ -1,0 +1,18 @@
+#if canImport(UIKit)
+    @testable import SearchTextField
+    import XCTest
+
+    class SearchTextFieldTest: XCTestCase {
+        override func setUp() {
+            // add setup code
+        }
+
+        override func tearDown() {
+            // add tear down code
+        }
+
+        func testSearchTextField() {
+            // add test code
+        }
+    }
+#endif


### PR DESCRIPTION
When the placeholder for the textfield is set to an empty string (textField.placeholder = ""). In the buildPlaceholderLabel() method, using attribute(.foregroundColor, at: 0, effectiveRange: nil) for an empty string will cause crash.

```
            if let placeholderColor = self.attributedPlaceholder?.attribute(NSAttributedString.Key.foregroundColor, at: 0, effectiveRange: nil) as? UIColor {
                placeholderLabel?.textColor = placeholderColor
            }
```

 So I add the code to check if the attributedPlaceholder is empty before calling attribute() method.

```
            if let attributedPlaceholder = self.attributedPlaceholder, attributedPlaceholder.length > 0,
               let placeholderColor = attributedPlaceholder.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? UIColor {
                placeholderLabel?.textColor = placeholderColor
            }
```

This branch also merge @pateldhruvil96 's fix for Swift Package Manager support, and remove deprecated method from iOS 13. 